### PR TITLE
Move volk into GR_REQUIRED_COMPONENTS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,7 @@ find_package(CppUnit)
 # of GR_REQUIRED_COMPONENTS (in all caps) and change "version" to the
 # minimum API compatible version required.
 #
-set(GR_REQUIRED_COMPONENTS RUNTIME BLOCKS FILTER PMT)
+set(GR_REQUIRED_COMPONENTS RUNTIME BLOCKS FILTER PMT VOLK)
 find_package(Gnuradio "3.7.2" REQUIRED)
 
 if(NOT GNURADIO_RUNTIME_FOUND)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -21,7 +21,7 @@
 include(GrPlatform) #define LIB_SUFFIX
 
 include_directories(${Boost_INCLUDE_DIR})
-link_directories(${Boost_LIBRARY_DIRS})
+link_directories(${Boost_LIBRARY_DIRS} ${GNURADIO_RUNTIME_LIBRARY_DIRS})
 
 list(APPEND tpms_sources
     ask_env_impl.cc
@@ -30,7 +30,7 @@ list(APPEND tpms_sources
 )
 
 add_library(gnuradio-tpms SHARED ${tpms_sources})
-target_link_libraries(gnuradio-tpms ${Boost_LIBRARIES} ${GNURADIO_RUNTIME_LIBRARIES} ${GNURADIO_ALL_LIBRARIES} fftw3f volk)
+target_link_libraries(gnuradio-tpms ${Boost_LIBRARIES} ${GNURADIO_RUNTIME_LIBRARIES} ${GNURADIO_ALL_LIBRARIES} fftw3f)
 set_target_properties(gnuradio-tpms PROPERTIES DEFINE_SYMBOL "gnuradio_tpms_EXPORTS")
 
 ########################################################################


### PR DESCRIPTION
Fixes a linking error, possibly related to my gnuradio
installation being in /opt

Linking CXX shared library libgnuradio-tpms.so
/usr/bin/ld: cannot find -lvolk
collect2: error: ld returned 1 exit status
lib/CMakeFiles/gnuradio-tpms.dir/build.make:146: recipe for target 'lib/libgnuradio-tpms.so' failed
make[2]: *** [lib/libgnuradio-tpms.so] Error 1